### PR TITLE
Example Adding Custom Listener

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -58,6 +58,15 @@ export default class ExternalScene extends window.BaseScene {
 
   update() {
     super.update();
+
+    if (!this.listener) {
+      this.listener =
+        this.mmoService.state.context.server?.state.messages.onAdd(
+          (message: any) => {
+            console.log("Incoming transmission...", message);
+          }
+        );
+    }
   }
 
   PlaceCustomNPC(npc: CustomNPC) {


### PR DESCRIPTION
## Example Adding Custom Listeners

@0xSacul This is an example of adding custom listeners. The server state is injected by the `BaseScene` under `this.mmoService.state.context.server?.state`.

Please note that the initialisation of the server is asynchronous to to the initialisation of the phaser scene. Hence adding the listener has been deferred to the update loop.
